### PR TITLE
Add `publish = false` to prevent misoperation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "ac-library-rs"
 version = "0.1.0"
 authors = ["matsu7874 <mtsmtkmt@gmail.com>"]
 edition = "2018"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
`cargo publish command` would actually publish the `ac-library-rs` before <kbd>Ctrl-C</kbd> since it has no dependencies.
