### PR TITLE
Ignore .idea

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+.idea


### PR DESCRIPTION
Let's filter `.idea` directory out, which is a directory used to store IntelliJ/CLion configuration files.