### PR TITLE
Create `prelude` module and move the re-exported items to it

### DIFF
--- a/examples/practice2_d_maxflow.rs
+++ b/examples/practice2_d_maxflow.rs
@@ -1,4 +1,4 @@
-use ac_library_rs::MfGraph;
+use ac_library_rs::prelude::*;
 use std::io::Read;
 
 #[allow(clippy::many_single_char_names)]

--- a/examples/practice2_j_segment_tree.rs
+++ b/examples/practice2_j_segment_tree.rs
@@ -1,4 +1,4 @@
-use ac_library_rs::{Max, Segtree};
+use ac_library_rs::prelude::*;
 use std::io::Read;
 
 fn main() {

--- a/examples/practice2_k_range_affine_range_sum.rs
+++ b/examples/practice2_k_range_affine_range_sum.rs
@@ -1,4 +1,4 @@
-use ac_library_rs::{LazySegtree, MapMonoid, ModInt998244353, Monoid};
+use ac_library_rs::prelude::*;
 use std::io::Read;
 
 type Mint = ModInt998244353;

--- a/examples/practice2_l_lazy_segment_tree.rs
+++ b/examples/practice2_l_lazy_segment_tree.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::many_single_char_names)]
-use ac_library_rs::{LazySegtree, MapMonoid, Monoid};
+use ac_library_rs::prelude::*;
 use std::io::Read;
 use std::iter;
 

--- a/src/convolution.rs
+++ b/src/convolution.rs
@@ -8,9 +8,9 @@ macro_rules! modulus {
                 const VALUE: u32 = $name as _;
                 const HINT_VALUE_IS_PRIME: bool = true;
 
-                fn butterfly_cache() -> &'static ::std::thread::LocalKey<::std::cell::RefCell<::std::option::Option<$crate::modint::ButterflyCache<Self>>>> {
+                fn butterfly_cache() -> &'static ::std::thread::LocalKey<::std::cell::RefCell<::std::option::Option<self::modint::ButterflyCache<Self>>>> {
                     thread_local! {
-                        static BUTTERFLY_CACHE: ::std::cell::RefCell<::std::option::Option<$crate::modint::ButterflyCache<$name>>> = ::std::default::Default::default();
+                        static BUTTERFLY_CACHE: ::std::cell::RefCell<::std::option::Option<self::modint::ButterflyCache<$name>>> = ::std::default::Default::default();
                     }
                     &BUTTERFLY_CACHE
                 }
@@ -21,7 +21,7 @@ macro_rules! modulus {
 
 use super::{
     internal_bit, internal_math,
-    modint::{ButterflyCache, Modulus, RemEuclidU32, StaticModInt},
+    modint::{self, ButterflyCache, Modulus, RemEuclidU32, StaticModInt},
 };
 use std::{
     cmp,
@@ -232,7 +232,7 @@ fn prepare<M: Modulus>() -> ButterflyCache<M> {
 
 #[cfg(test)]
 mod tests {
-    use super::super::modint::{Mod998244353, Modulus, RemEuclidU32, StaticModInt};
+    use super::super::modint::{self, Mod998244353, Modulus, RemEuclidU32, StaticModInt};
     use rand::{rngs::ThreadRng, Rng as _};
     use std::{
         convert::{TryFrom, TryInto as _},

--- a/src/convolution.rs
+++ b/src/convolution.rs
@@ -8,9 +8,9 @@ macro_rules! modulus {
                 const VALUE: u32 = $name as _;
                 const HINT_VALUE_IS_PRIME: bool = true;
 
-                fn butterfly_cache() -> &'static ::std::thread::LocalKey<::std::cell::RefCell<::std::option::Option<crate::modint::ButterflyCache<Self>>>> {
+                fn butterfly_cache() -> &'static ::std::thread::LocalKey<::std::cell::RefCell<::std::option::Option<$crate::modint::ButterflyCache<Self>>>> {
                     thread_local! {
-                        static BUTTERFLY_CACHE: ::std::cell::RefCell<::std::option::Option<crate::modint::ButterflyCache<$name>>> = ::std::default::Default::default();
+                        static BUTTERFLY_CACHE: ::std::cell::RefCell<::std::option::Option<$crate::modint::ButterflyCache<$name>>> = ::std::default::Default::default();
                     }
                     &BUTTERFLY_CACHE
                 }
@@ -19,7 +19,7 @@ macro_rules! modulus {
     };
 }
 
-use crate::{
+use super::{
     internal_bit, internal_math,
     modint::{ButterflyCache, Modulus, RemEuclidU32, StaticModInt},
 };
@@ -232,10 +232,7 @@ fn prepare<M: Modulus>() -> ButterflyCache<M> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        modint::{Mod998244353, Modulus, StaticModInt},
-        RemEuclidU32,
-    };
+    use super::super::modint::{Mod998244353, Modulus, RemEuclidU32, StaticModInt};
     use rand::{rngs::ThreadRng, Rng as _};
     use std::{
         convert::{TryFrom, TryInto as _},

--- a/src/internal_math.rs
+++ b/src/internal_math.rs
@@ -228,7 +228,7 @@ pub(crate) fn primitive_root(m: i32) -> i32 {
 mod tests {
     #![allow(clippy::unreadable_literal)]
     #![allow(clippy::cognitive_complexity)]
-    use crate::internal_math::{inv_gcd, is_prime, pow_mod, primitive_root, safe_mod, Barrett};
+    use super::{inv_gcd, is_prime, pow_mod, primitive_root, safe_mod, Barrett};
     use std::collections::HashSet;
 
     #[test]

--- a/src/internal_queue.rs
+++ b/src/internal_queue.rs
@@ -51,7 +51,7 @@ impl<T> SimpleQueue<T> {
 
 #[cfg(test)]
 mod test {
-    use crate::internal_queue::SimpleQueue;
+    use super::SimpleQueue;
 
     #[allow(clippy::cognitive_complexity)]
     #[test]

--- a/src/lazysegtree.rs
+++ b/src/lazysegtree.rs
@@ -1,5 +1,5 @@
-use crate::internal_bit::ceil_pow2;
-use crate::Monoid;
+use super::internal_bit::ceil_pow2;
+use super::Monoid;
 
 pub trait MapMonoid {
     type M: Monoid;
@@ -314,7 +314,8 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::{LazySegtree, MapMonoid, Max};
+    use super::super::segtree::Max;
+    use super::{LazySegtree, MapMonoid};
 
     struct MaxAdd;
     impl MapMonoid for MaxAdd {

--- a/src/lazysegtree.rs
+++ b/src/lazysegtree.rs
@@ -1,5 +1,5 @@
 use super::internal_bit::ceil_pow2;
-use super::Monoid;
+use super::segtree::Monoid;
 
 pub trait MapMonoid {
     type M: Monoid;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod math;
 pub mod maxflow;
 pub mod mincostflow;
 pub mod modint;
+pub mod prelude;
 pub mod scc;
 pub mod segtree;
 pub mod string;
@@ -16,22 +17,3 @@ pub(crate) mod internal_math;
 pub(crate) mod internal_queue;
 pub(crate) mod internal_scc;
 pub(crate) mod internal_type_traits;
-
-pub use convolution::{convolution, convolution_i64};
-pub use dsu::Dsu;
-pub use fenwicktree::FenwickTree;
-pub use lazysegtree::{LazySegtree, MapMonoid};
-pub use math::{crt, floor_sum, inv_mod, pow_mod};
-pub use maxflow::{Edge, MfGraph};
-pub use mincostflow::MinCostFlowGraph;
-pub use modint::{
-    Barrett, ButterflyCache, DefaultId, DynamicModInt, Id, Mod1000000007, Mod998244353, ModInt,
-    ModInt1000000007, ModInt998244353, Modulus, RemEuclidU32, StaticModInt,
-};
-pub use scc::SccGraph;
-pub use segtree::{Additive, Max, Min, Monoid, Multiplicative, Segtree};
-pub use string::{
-    lcp_array, lcp_array_arbitrary, suffix_array, suffix_array_arbitrary, suffix_array_manual,
-    z_algorithm, z_algorithm_arbitrary,
-};
-pub use twosat::TwoSat;

--- a/src/math.rs
+++ b/src/math.rs
@@ -1,4 +1,4 @@
-use crate::internal_math;
+use super::internal_math;
 
 use std::mem::swap;
 

--- a/src/maxflow.rs
+++ b/src/maxflow.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
-use crate::internal_queue::SimpleQueue;
-use crate::internal_type_traits::Integral;
+use super::internal_queue::SimpleQueue;
+use super::internal_type_traits::Integral;
 use std::cmp::min;
 use std::iter;
 
@@ -226,7 +226,7 @@ struct _Edge<Cap> {
 
 #[cfg(test)]
 mod test {
-    use crate::{Edge, MfGraph};
+    use super::{Edge, MfGraph};
 
     #[test]
     fn test_max_flow_wikipedia() {

--- a/src/mincostflow.rs
+++ b/src/mincostflow.rs
@@ -1,4 +1,4 @@
-use crate::internal_type_traits::Integral;
+use super::internal_type_traits::Integral;
 
 pub struct MinCostFlowEdge<T> {
     pub from: usize,

--- a/src/modint.rs
+++ b/src/modint.rs
@@ -10,7 +10,7 @@
 //! - The type of the argument of `pow` is `u64`, not `i64`.
 //! - Modints implement `FromStr` and `Display`. Modints in the original ACL don't have `operator<<` or `operator>>`.
 
-use crate::internal_math;
+use super::internal_math;
 use std::{
     cell::RefCell,
     convert::{Infallible, TryInto as _},
@@ -681,7 +681,7 @@ impl_folding! {
 
 #[cfg(test)]
 mod tests {
-    use crate::modint::ModInt1000000007;
+    use super::ModInt1000000007;
 
     #[test]
     fn static_modint_new() {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,20 @@
+pub use super::{
+    convolution::{convolution, convolution_i64},
+    dsu::Dsu,
+    fenwicktree::FenwickTree,
+    lazysegtree::{LazySegtree, MapMonoid},
+    math::{crt, floor_sum, inv_mod, pow_mod},
+    maxflow::{Edge, MfGraph},
+    mincostflow::MinCostFlowGraph,
+    modint::{
+        Barrett, ButterflyCache, DynamicModInt, Id, Mod1000000007, Mod998244353, ModInt,
+        ModInt1000000007, ModInt998244353, Modulus, StaticModInt,
+    },
+    scc::SccGraph,
+    segtree::{Additive, Max, Min, Monoid, Multiplicative, Segtree},
+    string::{
+        lcp_array, lcp_array_arbitrary, suffix_array, suffix_array_arbitrary, suffix_array_manual,
+        z_algorithm, z_algorithm_arbitrary,
+    },
+    twosat::TwoSat,
+};

--- a/src/scc.rs
+++ b/src/scc.rs
@@ -1,4 +1,4 @@
-use crate::internal_scc;
+use super::internal_scc;
 
 pub struct SccGraph {
     internal: internal_scc::SccGraph,

--- a/src/segtree.rs
+++ b/src/segtree.rs
@@ -1,5 +1,5 @@
-use crate::internal_bit::ceil_pow2;
-use crate::internal_type_traits::{BoundedAbove, BoundedBelow, One, Zero};
+use super::internal_bit::ceil_pow2;
+use super::internal_type_traits::{BoundedAbove, BoundedBelow, One, Zero};
 use std::cmp::{max, min};
 use std::convert::Infallible;
 use std::marker::PhantomData;
@@ -238,8 +238,8 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::segtree::Max;
-    use crate::Segtree;
+    use super::super::Segtree;
+    use super::Max;
 
     #[test]
     fn test_max_segtree() {

--- a/src/segtree.rs
+++ b/src/segtree.rs
@@ -238,7 +238,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::super::Segtree;
+    use super::super::segtree::Segtree;
     use super::Max;
 
     #[test]

--- a/src/twosat.rs
+++ b/src/twosat.rs
@@ -1,4 +1,4 @@
-use crate::internal_scc;
+use super::internal_scc;
 
 pub struct TwoSat {
     n: usize,


### PR DESCRIPTION
Adead of #63.

https://github.com/rust-lang-ja/ac-library-rs/pull/6#issuecomment-688566460

This crate will be unlikely introduced to the system of AtCoder. Users have to use `expand.py` or other tools.

Whole code of ac-library-rs is already larger than 64KiB and it's about 40KiB even if minified. To use ac-library-rs in other contest platforms, users have to exclude unused modules. When users use ac-library in Codeforces or somewhere, collection of the re-exported items cannot be used. They are even obstacle when using other code expansion tools.

Or rather, current `expand.py` does not read `lib.rs` and it is hard to do.
