### PR TITLE
Fix the version of `rand`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ publish = false
 
 [dev-dependencies]
 proconio = "=0.3.6"
-rand = "0.7.3"
+rand = "=0.7.3"


### PR DESCRIPTION
To make it compatible with the crate versions on AtCoder.

See: https://github.com/rust-lang-ja/atcoder-rust-base/blob/c61d275ff82a40951e64c771d1680da515b9f421/Cargo.lock