### PR TITLE
Fix compatibility with cargo-equip

### DIFF
--- a/src/convolution.rs
+++ b/src/convolution.rs
@@ -8,9 +8,9 @@ macro_rules! modulus {
                 const VALUE: u32 = $name as _;
                 const HINT_VALUE_IS_PRIME: bool = true;
 
-                fn butterfly_cache() -> &'static ::std::thread::LocalKey<::std::cell::RefCell<::std::option::Option<crate::modint::ButterflyCache<Self>>>> {
+                fn butterfly_cache() -> &'static ::std::thread::LocalKey<::std::cell::RefCell<::std::option::Option<$crate::modint::ButterflyCache<Self>>>> {
                     thread_local! {
-                        static BUTTERFLY_CACHE: ::std::cell::RefCell<::std::option::Option<crate::modint::ButterflyCache<$name>>> = ::std::default::Default::default();
+                        static BUTTERFLY_CACHE: ::std::cell::RefCell<::std::option::Option<$crate::modint::ButterflyCache<$name>>> = ::std::default::Default::default();
                     }
                     &BUTTERFLY_CACHE
                 }


### PR DESCRIPTION
Fix compatibility with cargo-equip .
I believe a number of people use ac-library-rs with cargo-equip. But so far, there are some incompatibilities and they are resolved by just two bytes change of ac-library-rs. Therefore, this PR will be useful for us.

Refer the constraints  #3 in the usage of cargo-equip: https://github.com/qryxip/cargo-equip

Signed-off-by: toast-uz