### PR TITLE
executing expand.py from outer dir

### DIFF
--- a/expand.py
+++ b/expand.py
@@ -4,6 +4,7 @@ import sys
 import getopt
 import tempfile
 import subprocess
+import pathlib
 
 usage = '''Usage:expand.py [options] <output modules>
 Output Modules:
@@ -43,14 +44,14 @@ dependency_list = {'convolution': ('internal_bit', 'modint',),
                    'scc': ('internal_scc',),
                    'segtree': ('internal_bit', 'internal_type_traits',),
                    'twosat': ('internal_scc',), }
-src_path = 'src/'
+src_path = pathlib.Path(sys.argv[0]).parent.joinpath('src')
 
 
 def output_file(filename):
     global src_path
 
     res = []
-    with open(src_path+filename+'.rs', 'r') as f:
+    with open(src_path.joinpath(filename+'.rs'), 'r') as f:
         res.append('pub mod {} {{'.format(filename))
 
         for line in f:


### PR DESCRIPTION
`expand.py` could fail when execution from outer directory.
```
% python3 ${HOME}/src/github.com/rust-lang-ja/ac-library-rs/expand.py segtree
Traceback (most recent call last):
  File "xxxxxxx/src/github.com/rust-lang-ja/ac-library-rs/expand.py", line 99, in <module>
    buf = output_file(i)
  File "xxxxxxx/src/github.com/rust-lang-ja/ac-library-rs/expand.py", line 53, in output_file
    with open(src_path+filename+'.rs', 'r') as f:
FileNotFoundError: [Errno 2] No such file or directory: 'src/internal_bit.rs'
```

It can be solved with reference of `argv[0]`