### PR TITLE
Implement `Zero`, `One`, and `Pow` for Modint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+num-traits = { version = "0.2.11", optional = true }
 
 [dev-dependencies]
 input = { path = "./crates/input" }

--- a/src/modint.rs
+++ b/src/modint.rs
@@ -898,6 +898,39 @@ macro_rules! impl_basic_traits {
             }
         }
 
+        #[cfg(feature = "num-traits")]
+        impl<$generic_param: $generic_param_bound> num_traits::Zero for $self {
+            #[inline]
+            fn zero() -> Self {
+                Self::new(0)
+            }
+            #[inline]
+            fn is_zero(&self) -> bool {
+                self == &Self::zero()
+            }
+        }
+
+        #[cfg(feature = "num-traits")]
+        impl<$generic_param: $generic_param_bound> num_traits::One for $self {
+            #[inline]
+            fn one() -> Self {
+                Self::new(1)
+            }
+            #[inline]
+            fn is_one(&self) -> bool {
+                self == &Self::one()
+            }
+        }
+
+        #[cfg(feature = "num-traits")]
+        impl<$generic_param: $generic_param_bound> num_traits::Pow<u64> for $self {
+            type Output=$self;
+            #[inline]
+            fn pow(self, rhs: u64) -> Self::Output {
+                self.pow(rhs)
+            }
+        }
+
         impl_basic_traits!($($rest)*);
     };
 }


### PR DESCRIPTION
I added `num-traits` as an **optional** dependency so that we may use libraries requiring `Zero`, `One`, and so on, **only when** we know the library is available in that environment.