### PR TITLE
Make all types that implements `::num_traits::Zero` implement `crate::num_traits::Zero`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+num-traits = { version = "0.2.11", optional = true }
 
 [dev-dependencies]
 input = { path = "./crates/input" }

--- a/examples/library-checker-static-range-sum.rs
+++ b/examples/library-checker-static-range-sum.rs
@@ -15,7 +15,7 @@ fn main() {
         lrs: [(usize, usize); q],
     }
 
-    let mut fenwick = FenwickTree::new(n, 0);
+    let mut fenwick = FenwickTree::<u64>::new(n);
     for (i, a) in r#as.into_iter().enumerate() {
         fenwick.add(i, a);
     }

--- a/src/fenwicktree.rs
+++ b/src/fenwicktree.rs
@@ -1,20 +1,20 @@
+use crate::num_traits::Zero;
+
 // Reference: https://en.wikipedia.org/wiki/Fenwick_tree
 pub struct FenwickTree<T> {
     n: usize,
     ary: Vec<T>,
-    e: T,
 }
 
-impl<T: Clone + std::ops::AddAssign<T>> FenwickTree<T> {
-    pub fn new(n: usize, e: T) -> Self {
+impl<T: Clone + std::ops::AddAssign<T> + Zero> FenwickTree<T> {
+    pub fn new(n: usize) -> Self {
         FenwickTree {
             n,
-            ary: vec![e.clone(); n],
-            e,
+            ary: vec![T::zero(); n],
         }
     }
     pub fn accum(&self, mut idx: usize) -> T {
-        let mut sum = self.e.clone();
+        let mut sum = T::zero();
         while idx > 0 {
             sum += self.ary[idx - 1].clone();
             idx &= idx - 1;
@@ -48,7 +48,7 @@ mod tests {
 
     #[test]
     fn fenwick_tree_works() {
-        let mut bit = FenwickTree::new(5, 0i64);
+        let mut bit = FenwickTree::<i64>::new(5);
         // [1, 2, 3, 4, 5]
         for i in 0..5 {
             bit.add(i, i as i64 + 1);

--- a/src/internal_type_traits.rs
+++ b/src/internal_type_traits.rs
@@ -52,23 +52,11 @@ pub trait Integral:
     + fmt::Debug
     + fmt::Binary
     + fmt::Octal
-    + Zero
-    + One
+    + crate::num_traits::Zero
+    + crate::num_traits::One
     + BoundedBelow
     + BoundedAbove
 {
-}
-
-/// Class that has additive identity element
-pub trait Zero {
-    /// The additive identity element
-    fn zero() -> Self;
-}
-
-/// Class that has multiplicative identity element
-pub trait One {
-    /// The multiplicative identity element
-    fn one() -> Self;
 }
 
 pub trait BoundedBelow {
@@ -82,20 +70,6 @@ pub trait BoundedAbove {
 macro_rules! impl_integral {
     ($($ty:ty),*) => {
         $(
-            impl Zero for $ty {
-                #[inline]
-                fn zero() -> Self {
-                    0
-                }
-            }
-
-            impl One for $ty {
-                #[inline]
-                fn one() -> Self {
-                    1
-                }
-            }
-
             impl BoundedBelow for $ty {
                 #[inline]
                 fn min_value() -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,8 @@ pub mod segtree;
 pub mod string;
 pub mod twosat;
 
+pub mod num_traits;
+
 pub(crate) mod internal_bit;
 pub(crate) mod internal_math;
 pub(crate) mod internal_queue;

--- a/src/modint.rs
+++ b/src/modint.rs
@@ -898,6 +898,39 @@ macro_rules! impl_basic_traits {
             }
         }
 
+        #[cfg(feature = "num-traits")]
+        impl<$generic_param: $generic_param_bound> num_traits::Zero for $self {
+            #[inline]
+            fn zero() -> Self {
+                Self::new(0)
+            }
+            #[inline]
+            fn is_zero(&self) -> bool {
+                self == &Self::zero()
+            }
+        }
+
+        #[cfg(feature = "num-traits")]
+        impl<$generic_param: $generic_param_bound> num_traits::One for $self {
+            #[inline]
+            fn one() -> Self {
+                Self::new(1)
+            }
+            #[inline]
+            fn is_one(&self) -> bool {
+                self == &Self::one()
+            }
+        }
+
+        #[cfg(feature = "num-traits")]
+        impl<$generic_param: $generic_param_bound> num_traits::Pow<u64> for $self {
+            type Output=$self;
+            #[inline]
+            fn pow(self, rhs: u64) -> Self::Output {
+                self.pow(rhs)
+            }
+        }
+
         impl_basic_traits!($($rest)*);
     };
 }

--- a/src/modint.rs
+++ b/src/modint.rs
@@ -910,6 +910,14 @@ macro_rules! impl_basic_traits {
             }
         }
 
+        #[cfg(not(feature = "num-traits"))]
+        impl<$generic_param: $generic_param_bound> $crate::num_traits::Zero for $self {
+            #[inline]
+            fn zero() -> Self {
+                Self::new(0)
+            }
+        }
+
         #[cfg(feature = "num-traits")]
         impl<$generic_param: $generic_param_bound> num_traits::One for $self {
             #[inline]
@@ -919,6 +927,14 @@ macro_rules! impl_basic_traits {
             #[inline]
             fn is_one(&self) -> bool {
                 self == &Self::one()
+            }
+        }
+
+        #[cfg(not(feature = "num-traits"))]
+        impl<$generic_param: $generic_param_bound> $crate::num_traits::One for $self {
+            #[inline]
+            fn one() -> Self {
+                Self::new(1)
             }
         }
 

--- a/src/num_traits.rs
+++ b/src/num_traits.rs
@@ -3,22 +3,36 @@ pub trait Zero {
     /// The additive identity element.
     fn zero() -> Self;
 }
+#[cfg(feature = "num-traits")]
+impl<T: num_traits::Zero> Zero for T {
+    fn zero() -> Self {
+        num_traits::Zero::zero()
+    }
+}
 
 /// A type that has a multiplicative identity element.
 pub trait One {
     /// The multiplicative identity element.
     fn one() -> Self;
 }
+#[cfg(feature = "num-traits")]
+impl<T: num_traits::One> One for T {
+    fn one() -> Self {
+        num_traits::One::one()
+    }
+}
 
 macro_rules! impl_zero {
     ($zero: literal, $one: literal: $($t: ty),*) => {
         $(
+            #[cfg(not(feature="num-traits"))]
             impl Zero for $t {
                 fn zero() -> Self {
                     $zero
                 }
             }
 
+            #[cfg(not(feature="num-traits"))]
             impl One for $t {
                 fn one() -> Self {
                     $one
@@ -31,11 +45,13 @@ impl_zero!(0, 1: usize, u8, u16, u32, u64, u128);
 impl_zero!(0, 1: isize, i8, i16, i32, i64, i128);
 impl_zero!(0.0, 1.0: f32, f64);
 
+#[cfg(not(feature = "num-traits"))]
 impl<T: Zero> Zero for core::num::Wrapping<T> {
     fn zero() -> Self {
         Self(T::zero())
     }
 }
+#[cfg(not(feature = "num-traits"))]
 impl<T: One> One for core::num::Wrapping<T> {
     fn one() -> Self {
         Self(T::one())

--- a/src/num_traits.rs
+++ b/src/num_traits.rs
@@ -1,0 +1,43 @@
+/// A type that has an additive identity element.
+pub trait Zero {
+    /// The additive identity element.
+    fn zero() -> Self;
+}
+
+/// A type that has a multiplicative identity element.
+pub trait One {
+    /// The multiplicative identity element.
+    fn one() -> Self;
+}
+
+macro_rules! impl_zero {
+    ($zero: literal, $one: literal: $($t: ty),*) => {
+        $(
+            impl Zero for $t {
+                fn zero() -> Self {
+                    $zero
+                }
+            }
+
+            impl One for $t {
+                fn one() -> Self {
+                    $one
+                }
+            }
+        )*
+    };
+}
+impl_zero!(0, 1: usize, u8, u16, u32, u64, u128);
+impl_zero!(0, 1: isize, i8, i16, i32, i64, i128);
+impl_zero!(0.0, 1.0: f32, f64);
+
+impl<T: Zero> Zero for core::num::Wrapping<T> {
+    fn zero() -> Self {
+        Self(T::zero())
+    }
+}
+impl<T: One> One for core::num::Wrapping<T> {
+    fn one() -> Self {
+        Self(T::one())
+    }
+}

--- a/src/segtree.rs
+++ b/src/segtree.rs
@@ -1,5 +1,6 @@
 use crate::internal_bit::ceil_pow2;
-use crate::internal_type_traits::{BoundedAbove, BoundedBelow, One, Zero};
+use crate::internal_type_traits::{BoundedAbove, BoundedBelow};
+use crate::num_traits::{One, Zero};
 use std::cmp::{max, min};
 use std::convert::Infallible;
 use std::marker::PhantomData;


### PR DESCRIPTION
This PR depends on #102 and #105.  In addition to the changes applied in the PRs, this PR has a bonus: every type that implements `::num_traits::Zero` implements `crate::num_traits::Zero` too.  Therefore, if your crate depends on `num_traits` and have a type that implement `::num_traits::Zero` and want to use it for Fenwick Tree, you can just use it without suffering.  On the other hands, even fi your crate does not depend on `num_traits` but still want to use your own type for Fenwick Tree, you can manually implement `crate::num_traits::Zero`.