### PR TITLE
Implement FromIterator for Lazy/Segtree and improve performance

### DIFF
--- a/src/segtree.rs
+++ b/src/segtree.rs
@@ -1,7 +1,8 @@
 use crate::internal_bit::ceil_pow2;
 use crate::internal_type_traits::{BoundedAbove, BoundedBelow, One, Zero};
-use std::cmp::{max, min};
+use std::cmp::{max, min, Ordering};
 use std::convert::Infallible;
+use std::iter::{empty, repeat_with};
 use std::marker::PhantomData;
 use std::ops::{Add, Mul};
 
@@ -80,19 +81,35 @@ impl<M: Monoid> Segtree<M> {
 }
 impl<M: Monoid> From<Vec<M::S>> for Segtree<M> {
     fn from(v: Vec<M::S>) -> Self {
-        let n = v.len();
+        Self::from_vec(v, 0)
+    }
+}
+impl<M: Monoid> Segtree<M> {
+    /// Creates a segtree from elements `d[offset..]`.
+    fn from_vec(mut d: Vec<M::S>, offset: usize) -> Self {
+        assert!(offset <= d.len());
+        let n = d.len() - offset;
         let log = ceil_pow2(n as u32) as usize;
         let size = 1 << log;
-        let mut d = vec![M::identity(); 2 * size];
-        d[size..(size + n)].clone_from_slice(&v);
+        match offset.cmp(&size) {
+            Ordering::Less => {
+                d.splice(0..0, repeat_with(M::identity).take(size - offset));
+            }
+            Ordering::Equal => {}
+            Ordering::Greater => {
+                d.splice(size..offset, empty());
+            }
+        };
+        d.resize_with(size * 2, M::identity);
         let mut ret = Segtree { n, size, log, d };
         for i in (1..size).rev() {
             ret.update(i);
         }
+        // `ret.d[0]` is uninitialized and has an unknown value.
+        // This is ok as it is unused (as of writing).
         ret
     }
-}
-impl<M: Monoid> Segtree<M> {
+
     pub fn set(&mut self, mut p: usize, x: M::S) {
         assert!(p < self.n);
         p += self.size;
@@ -238,7 +255,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::segtree::Max;
+    use crate::segtree::{Additive, Max};
     use crate::Segtree;
 
     #[test]
@@ -311,5 +328,36 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn test_from_vec() {
+        let v = vec![1, 2, 4];
+        let ans_124 = vec![7, 3, 4, 1, 2, 4, 0];
+        let tree = Segtree::<Additive<_>>::from_vec(v, 0);
+        assert_eq!(&tree.d[1..], &ans_124[..]);
+
+        let v = vec![1, 2, 4, 8];
+        let tree = Segtree::<Additive<_>>::from_vec(v, 0);
+        assert_eq!(&tree.d[1..], &vec![15, 3, 12, 1, 2, 4, 8][..]);
+
+        let v = vec![1, 2, 4, 8, 16];
+        let tree = Segtree::<Additive<_>>::from_vec(v, 0);
+        assert_eq!(
+            &tree.d[1..],
+            &vec![31, 15, 16, 3, 12, 16, 0, 1, 2, 4, 8, 16, 0, 0, 0][..]
+        );
+
+        let v = vec![314, 159, 265, 1, 2, 4];
+        let tree = Segtree::<Additive<_>>::from_vec(v, 3);
+        assert_eq!(&tree.d[1..], &ans_124[..]);
+
+        let v = vec![314, 159, 265, 897, 1, 2, 4];
+        let tree = Segtree::<Additive<_>>::from_vec(v, 4);
+        assert_eq!(&tree.d[1..], &ans_124[..]);
+
+        let v = vec![314, 159, 265, 897, 932, 1, 2, 4];
+        let tree = Segtree::<Additive<_>>::from_vec(v, 5);
+        assert_eq!(&tree.d[1..], &ans_124[..]);
     }
 }


### PR DESCRIPTION
I implemented `FromIter` for Segtree and LazySegtree.  Additionally, I improved a bit the performance of creating a segtree from Vec by reusing the allocated space if applicable.