### PR TITLE
Work clippy

### DIFF
--- a/src/maxflow.rs
+++ b/src/maxflow.rs
@@ -22,7 +22,7 @@ where
         assert!(Cap::zero() <= cap);
         let m = self.pos.len();
         self.pos.push((from, self.g[from].len()));
-        let rev = self.g[to].len() + if from == to { 1 } else { 0 };
+        let rev = self.g[to].len() + usize::from(from == to);
         self.g[from].push(_Edge { to, rev, cap });
         let rev = self.g[from].len() - 1;
         self.g[to].push(_Edge {

--- a/src/string.rs
+++ b/src/string.rs
@@ -41,12 +41,8 @@ fn sa_doubling(s: &[i32]) -> Vec<usize> {
         sa.sort_by(cmp);
         tmp[sa[0]] = 0;
         for i in 1..n {
-            tmp[sa[i]] = tmp[sa[i - 1]]
-                + if cmp(&sa[i - 1], &sa[i]) == std::cmp::Ordering::Less {
-                    1
-                } else {
-                    0
-                };
+            tmp[sa[i]] =
+                tmp[sa[i - 1]] + i32::from(cmp(&sa[i - 1], &sa[i]) == std::cmp::Ordering::Less);
         }
         std::mem::swap(&mut tmp, &mut rnk);
         k *= 2;
@@ -253,11 +249,9 @@ pub fn lcp_array_arbitrary<T: Ord>(s: &[T], sa: &[usize]) -> Vec<usize> {
         rnk[sa[i]] = i;
     }
     let mut lcp = vec![0; n - 1];
-    let mut h = 0;
+    let mut h: usize = 0;
     for i in 0..n - 1 {
-        if h > 0 {
-            h -= 1;
-        }
+        h = h.saturating_sub(1);
         if rnk[i] == 0 {
             continue;
         }


### PR DESCRIPTION
Dependent PR:
https://github.com/rust-lang-ja/ac-library-rs/pull/109 Remove the hand-made `input!`

Related PR:
https://github.com/rust-lang-ja/ac-library-rs/pull/108 Workaround for Japanese Windows environment
https://github.com/rust-lang-ja/ac-library-rs/pull/112 u32 modulo fix

fixes:
https://rust-lang.github.io/rust-clippy/master/index.html#bool_to_int_with_if
https://rust-lang.github.io/rust-clippy/master/index.html#implicit_saturating_sub
