### PR TITLE
Segtree: Monoid BitwiseOr/BitwiseAnd/BitwiseXor, get_slice

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,9 @@ pub use modint::{
     ModInt1000000007, ModInt998244353, Modulus, RemEuclidU32, StaticModInt,
 };
 pub use scc::SccGraph;
-pub use segtree::{Additive, Max, Min, Monoid, Multiplicative, Segtree};
+pub use segtree::{
+    Additive, BitwiseAnd, BitwiseOr, BitwiseXor, Max, Min, Monoid, Multiplicative, Segtree,
+};
 pub use string::{
     lcp_array, lcp_array_arbitrary, suffix_array, suffix_array_arbitrary, suffix_array_manual,
     z_algorithm, z_algorithm_arbitrary,

--- a/src/segtree.rs
+++ b/src/segtree.rs
@@ -3,7 +3,7 @@ use crate::internal_type_traits::{BoundedAbove, BoundedBelow, One, Zero};
 use std::cmp::{max, min};
 use std::convert::Infallible;
 use std::marker::PhantomData;
-use std::ops::{Add, Bound, Mul, RangeBounds};
+use std::ops::{Add, BitAnd, BitOr, BitXor, Bound, Mul, Not, RangeBounds};
 
 // TODO Should I split monoid-related traits to another module?
 pub trait Monoid {
@@ -65,6 +65,48 @@ where
     }
     fn binary_operation(a: &Self::S, b: &Self::S) -> Self::S {
         *a * *b
+    }
+}
+
+pub struct BitwiseOr<S>(Infallible, PhantomData<fn() -> S>);
+impl<S> Monoid for BitwiseOr<S>
+where
+    S: Copy + BitOr<Output = S> + Zero,
+{
+    type S = S;
+    fn identity() -> Self::S {
+        S::zero()
+    }
+    fn binary_operation(a: &Self::S, b: &Self::S) -> Self::S {
+        *a | *b
+    }
+}
+
+pub struct BitwiseAnd<S>(Infallible, PhantomData<fn() -> S>);
+impl<S> Monoid for BitwiseAnd<S>
+where
+    S: Copy + BitAnd<Output = S> + Not<Output = S> + Zero,
+{
+    type S = S;
+    fn identity() -> Self::S {
+        !S::zero()
+    }
+    fn binary_operation(a: &Self::S, b: &Self::S) -> Self::S {
+        *a & *b
+    }
+}
+
+pub struct BitwiseXor<S>(Infallible, PhantomData<fn() -> S>);
+impl<S> Monoid for BitwiseXor<S>
+where
+    S: Copy + BitXor<Output = S> + Zero,
+{
+    type S = S;
+    fn identity() -> Self::S {
+        S::zero()
+    }
+    fn binary_operation(a: &Self::S, b: &Self::S) -> Self::S {
+        *a ^ *b
     }
 }
 

--- a/src/segtree.rs
+++ b/src/segtree.rs
@@ -127,7 +127,7 @@ impl<M: Monoid> From<Vec<M::S>> for Segtree<M> {
         let log = ceil_pow2(n as u32) as usize;
         let size = 1 << log;
         let mut d = vec![M::identity(); 2 * size];
-        d[size..(size + n)].clone_from_slice(&v);
+        d[size..][..n].clone_from_slice(&v);
         let mut ret = Segtree { n, size, log, d };
         for i in (1..size).rev() {
             ret.update(i);
@@ -168,6 +168,10 @@ impl<M: Monoid> Segtree<M> {
     pub fn get(&self, p: usize) -> M::S {
         assert!(p < self.n);
         self.d[p + self.size].clone()
+    }
+
+    pub fn get_slice(&self) -> &[M::S] {
+        &self.d[self.size..][..self.n]
     }
 
     pub fn prod<R>(&self, range: R) -> M::S


### PR DESCRIPTION
- Monoid BitOrOper/BitAndOper/BitXorOper: for bool/bitset type segtree data
- FromIterator: struct from Iterator
- get_slice: allows slice access to internal data

usage sample: [ABC285F - Substring of Sorted String](https://atcoder.jp/contests/abc285/tasks/abc285_f)
https://atcoder.jp/contests/abc285/submissions/38317831
