### PR TITLE
Tentative solution for CI (Clippy error, deprecated warning)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: cargo-clippy
         run: |
-          ~/.cargo/bin/cargo clippy --workspace --all-targets -- -D warnings -D renamed-and-removed-lints
+          ~/.cargo/bin/cargo clippy --workspace --all-targets -- -A renamed-and-removed-lints -D warnings
 
       - name: cargo-build
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: 'Setup `${{ matrix.toolchain }}`'
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
           components: rustfmt
@@ -69,7 +69,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: 'Setup `${{ matrix.toolchain }}`'
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
           components: clippy
@@ -111,7 +111,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: 'Setup `${{ matrix.toolchain }}`'
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
           components: rustfmt
@@ -137,7 +137,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup `1.60.0-x86_64-unknown-linux-gnu`
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.60.0-x86_64-unknown-linux-gnu
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,11 @@ jobs:
 
       - name: 'Override `${{ matrix.toolchain }}'
         run: |
-          ~/.cargo/bin/rustup override set ${{ matrix.toolchain }}
+          rustup override set ${{ matrix.toolchain }}
 
       - name: cargo-fmt
         run: |
-          ~/.cargo/bin/cargo fmt --all -- --check
+          cargo fmt --all -- --check
 
   build:
     strategy:
@@ -76,19 +76,19 @@ jobs:
 
       - name: 'Override `${{ matrix.toolchain }}`'
         run: |
-          ~/.cargo/bin/rustup override set ${{ matrix.toolchain }}
+          rustup override set ${{ matrix.toolchain }}
 
       - name: cargo-clippy
         run: |
-          ~/.cargo/bin/cargo clippy --workspace --all-targets -- -A renamed-and-removed-lints -D warnings
+          cargo clippy --workspace --all-targets -- -A renamed-and-removed-lints -D warnings
 
       - name: cargo-build
         run: |
-          ~/.cargo/bin/cargo build --workspace --all-targets
+          cargo build --workspace --all-targets
 
       - name: cargo-test
         run: |
-          ~/.cargo/bin/cargo test --workspace --no-fail-fast
+          cargo test --workspace --no-fail-fast
         env:
           RUST_BACKTRACE: full
 
@@ -118,7 +118,7 @@ jobs:
 
       - name: 'Override `${{ matrix.toolchain }}`'
         run: |
-          ~/.cargo/bin/rustup override set ${{ matrix.toolchain }}
+          rustup override set ${{ matrix.toolchain }}
 
       - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
@@ -143,7 +143,7 @@ jobs:
 
       - name: 'Override `1.60.0-x86_64-unknown-linux-gnu'
         run: |
-          ~/.cargo/bin/rustup override set 1.60.0-x86_64-unknown-linux-gnu
+          rustup override set 1.60.0-x86_64-unknown-linux-gnu
 
       - name: Setup Python 3.9
         uses: actions/setup-python@v4
@@ -155,7 +155,7 @@ jobs:
 
       - name: cargo-build
         run: |
-          ~/.cargo/bin/cargo build --release --examples
+          cargo build --release --examples
 
       - name: Verify
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,13 @@ jobs:
         uses: actions/checkout@v3
 
       - name: 'Setup `${{ matrix.toolchain }}`'
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          components: rustfmt
+
+      - name: 'Override `${{ matrix.toolchain }}'
         run: |
-          ~/.cargo/bin/rustup show
-          ~/.cargo/bin/rustup -V
-          ~/.cargo/bin/rustup toolchain install ${{ matrix.toolchain }} --profile minimal --force --component rustfmt
           ~/.cargo/bin/rustup override set ${{ matrix.toolchain }}
 
       - name: cargo-fmt
@@ -66,10 +69,13 @@ jobs:
         uses: actions/checkout@v3
 
       - name: 'Setup `${{ matrix.toolchain }}`'
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          components: clippy
+
+      - name: 'Override `${{ matrix.toolchain }}`'
         run: |
-          ~/.cargo/bin/rustup show
-          ~/.cargo/bin/rustup -V
-          ~/.cargo/bin/rustup toolchain install ${{ matrix.toolchain }} --profile minimal --force --component clippy
           ~/.cargo/bin/rustup override set ${{ matrix.toolchain }}
 
       - name: cargo-clippy
@@ -105,10 +111,13 @@ jobs:
         uses: actions/checkout@v3
 
       - name: 'Setup `${{ matrix.toolchain }}`'
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          components: rustfmt
+
+      - name: 'Override `${{ matrix.toolchain }}`'
         run: |
-          ~/.cargo/bin/rustup show
-          ~/.cargo/bin/rustup -V
-          ~/.cargo/bin/rustup toolchain install ${{ matrix.toolchain }} --profile minimal --force --component rustfmt
           ~/.cargo/bin/rustup override set ${{ matrix.toolchain }}
 
       - name: Setup Python ${{ matrix.python-version }}
@@ -128,10 +137,12 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup `1.60.0-x86_64-unknown-linux-gnu`
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.60.0-x86_64-unknown-linux-gnu
+
+      - name: 'Override `1.60.0-x86_64-unknown-linux-gnu'
         run: |
-          ~/.cargo/bin/rustup show
-          ~/.cargo/bin/rustup -V
-          ~/.cargo/bin/rustup toolchain install 1.60.0-x86_64-unknown-linux-gnu --profile minimal --force
           ~/.cargo/bin/rustup override set 1.60.0-x86_64-unknown-linux-gnu
 
       - name: Setup Python 3.9

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,21 +22,18 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: 'Setup `${{ matrix.toolchain }}`'
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.toolchain }}
-          override: true
-          profile: minimal
-          components: rustfmt
+        run: |
+          ~/.cargo/bin/rustup show
+          ~/.cargo/bin/rustup -V
+          ~/.cargo/bin/rustup toolchain install ${{ matrix.toolchain }} --profile minimal --force --component rustfmt
+          ~/.cargo/bin/rustup override set ${{ matrix.toolchain }}
 
       - name: cargo-fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: |
+          ~/.cargo/bin/cargo fmt --all -- --check
 
   build:
     strategy:
@@ -66,33 +63,26 @@ jobs:
         if: matrix.os == 'windows-2019'
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: 'Setup `${{ matrix.toolchain }}`'
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.toolchain }}
-          override: true
-          profile: minimal
-          components: clippy
+        run: |
+          ~/.cargo/bin/rustup show
+          ~/.cargo/bin/rustup -V
+          ~/.cargo/bin/rustup toolchain install ${{ matrix.toolchain }} --profile minimal --force --component clippy
+          ~/.cargo/bin/rustup override set ${{ matrix.toolchain }}
 
       - name: cargo-clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --workspace --all-targets -- -D warnings
+        run: |
+          ~/.cargo/bin/cargo clippy --workspace --all-targets -- -D warnings -D renamed-and-removed-lints
 
       - name: cargo-build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --workspace --all-targets
+        run: |
+          ~/.cargo/bin/cargo build --workspace --all-targets
 
       - name: cargo-test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --workspace --no-fail-fast
+        run: |
+          ~/.cargo/bin/cargo test --workspace --no-fail-fast
         env:
           RUST_BACKTRACE: full
 
@@ -112,18 +102,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: 'Setup `${{ matrix.toolchain }}`'
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.toolchain }}
-          override: true
-          profile: minimal
-          components: rustfmt
+        run: |
+          ~/.cargo/bin/rustup show
+          ~/.cargo/bin/rustup -V
+          ~/.cargo/bin/rustup toolchain install ${{ matrix.toolchain }} --profile minimal --force --component rustfmt
+          ~/.cargo/bin/rustup override set ${{ matrix.toolchain }}
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -136,17 +125,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - name: Setup `1.47.0-x86_64-unknown-linux-gnu`
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.47.0-x86_64-unknown-linux-gnu
-          override: true
-          profile: minimal
+      - name: Setup `1.60.0-x86_64-unknown-linux-gnu`
+        run: |
+          ~/.cargo/bin/rustup show
+          ~/.cargo/bin/rustup -V
+          ~/.cargo/bin/rustup toolchain install 1.60.0-x86_64-unknown-linux-gnu --profile minimal --force
+          ~/.cargo/bin/rustup override set 1.60.0-x86_64-unknown-linux-gnu
 
       - name: Setup Python 3.9
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.9'
 
@@ -154,10 +143,8 @@ jobs:
         run: pip install online-judge-tools
 
       - name: cargo-build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --examples
+        run: |
+          ~/.cargo/bin/cargo build --release --examples
 
       - name: Verify
         run: |


### PR DESCRIPTION
* Rust 1.68 以降での、Clippy Lints のキーワードの変更 (`derive_hash_xor_eq` -> `derived_hash_with_manual_eq `) に伴うエラーを暫定的に回避します。
  * https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-168
  * https://github.com/rust-lang/rust-clippy/pull/10184
  * https://rust-lang.github.io/rust-clippy/master/index.html#derived_hash_with_manual_eq

* 非推奨となっている、 Node 12 を使用していた GitHub Actions を修正します。
  * `actions/checkout@v3`
  * `actions/setup-python@v4`
  * `actions-rs` is unmaintained:
    * https://github.com/actions-rs/toolchain/issues/219
    * https://github.com/actions-rs/cargo/issues/222

* Library Checker: Rust 1.60
  * https://judge.yosupo.jp/help
