### PR TITLE
ci: ubuntu-20.04, macos-11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           - stable-x86_64-unknown-linux-gnu
 
     name: Rustfmt (${{ matrix.toolchain }})
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout
@@ -51,11 +51,11 @@ jobs:
           - stable-x86_64-unknown-linux-gnu
         include:
           - { toolchain: 1.42.0-x86_64-pc-windows-msvc  , os: windows-2019 }
-          - { toolchain: 1.42.0-x86_64-apple-darwin     , os: macos-10.15  }
-          - { toolchain: 1.42.0-x86_64-unknown-linux-gnu, os: ubuntu-18.04 }
+          - { toolchain: 1.42.0-x86_64-apple-darwin     , os: macos-11     }
+          - { toolchain: 1.42.0-x86_64-unknown-linux-gnu, os: ubuntu-20.04 }
           - { toolchain: stable-x86_64-pc-windows-msvc  , os: windows-2019 }
-          - { toolchain: stable-x86_64-apple-darwin     , os: macos-10.15  }
-          - { toolchain: stable-x86_64-unknown-linux-gnu, os: ubuntu-18.04 }
+          - { toolchain: stable-x86_64-apple-darwin     , os: macos-11     }
+          - { toolchain: stable-x86_64-unknown-linux-gnu, os: ubuntu-20.04 }
 
     name: Build (${{ matrix.toolchain }})
     runs-on: ${{ matrix.os }}
@@ -104,7 +104,7 @@ jobs:
           - '3.8' # https://packages.ubuntu.com/focal/python3
 
     name: Expand_test (${{ matrix.toolchain }}, ${{ matrix.python-version }})
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout


### PR DESCRIPTION
If there is a desire to move to Ubuntu 22.04 or macos-12, that may be fine as well.

> The ubuntu-18.04 environment is deprecated, consider switching to ubuntu-20.04(ubuntu-latest), or ubuntu-22.04 instead. For more details see https://github.com/actions/virtual-environments/issues/6002

- https://github.com/actions/virtual-environments/issues/6002

> The macOS-10.15 environment is deprecated, consider switching to macos-11(macos-latest), macos-12 instead. For more details see https://github.com/actions/virtual-environments/issues/5583

- https://github.com/actions/virtual-environments/issues/5583