### PR TITLE
Rename the crate name to `acl`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ keywords = ["competitive"]
 categories = ["algorithms", "data-structures"]
 publish = false
 
+[lib]
+name = "acl"
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/examples/library-checker-convolution-mod.rs
+++ b/examples/library-checker-convolution-mod.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate proconio as _;
 
-use ac_library_rs::{convolution, modint::ModInt998244353 as Mint};
+use acl::{convolution, modint::ModInt998244353 as Mint};
 use std::fmt;
 
 fn main() {

--- a/examples/library-checker-static-range-sum.rs
+++ b/examples/library-checker-static-range-sum.rs
@@ -3,7 +3,7 @@ extern crate proconio as _;
 #[macro_use]
 extern crate proconio_derive as _;
 
-use ac_library_rs::fenwicktree::FenwickTree;
+use acl::fenwicktree::FenwickTree;
 
 #[allow(clippy::needless_collect)]
 #[fastout]

--- a/examples/library-checker-sum-of-floor-of-linear.rs
+++ b/examples/library-checker-sum-of-floor-of-linear.rs
@@ -3,7 +3,7 @@ extern crate proconio as _;
 #[macro_use]
 extern crate proconio_derive as _;
 
-use ac_library_rs::math;
+use acl::math;
 
 #[fastout]
 fn main() {

--- a/examples/library-checker-unionfind.rs
+++ b/examples/library-checker-unionfind.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate proconio as _;
 
-use ac_library_rs::dsu::Dsu;
+use acl::dsu::Dsu;
 
 fn main() {
     input! {

--- a/examples/practice2_d_maxflow.rs
+++ b/examples/practice2_d_maxflow.rs
@@ -1,4 +1,4 @@
-use ac_library_rs::MfGraph;
+use acl::MfGraph;
 use std::io::Read;
 
 #[allow(clippy::many_single_char_names)]

--- a/examples/practice2_j_segment_tree.rs
+++ b/examples/practice2_j_segment_tree.rs
@@ -1,4 +1,4 @@
-use ac_library_rs::{Max, Segtree};
+use acl::{Max, Segtree};
 use std::io::Read;
 
 fn main() {

--- a/examples/practice2_k_range_affine_range_sum.rs
+++ b/examples/practice2_k_range_affine_range_sum.rs
@@ -1,4 +1,4 @@
-use ac_library_rs::{LazySegtree, MapMonoid, ModInt998244353, Monoid};
+use acl::{LazySegtree, MapMonoid, ModInt998244353, Monoid};
 use std::io::Read;
 
 type Mint = ModInt998244353;

--- a/examples/practice2_l_lazy_segment_tree.rs
+++ b/examples/practice2_l_lazy_segment_tree.rs
@@ -1,5 +1,5 @@
 #![allow(clippy::many_single_char_names)]
-use ac_library_rs::{LazySegtree, MapMonoid, Monoid};
+use acl::{LazySegtree, MapMonoid, Monoid};
 use std::io::Read;
 use std::iter;
 

--- a/src/dsu.rs
+++ b/src/dsu.rs
@@ -9,7 +9,7 @@
 /// # Example
 ///
 /// ```
-/// use ac_library_rs::Dsu;
+/// use acl::Dsu;
 /// use proconio::{input, source::once::OnceSource};
 ///
 /// input! {

--- a/src/math.rs
+++ b/src/math.rs
@@ -22,7 +22,7 @@ use std::mem::swap;
 /// # Example
 ///
 /// ```
-/// use ac_library_rs::math;
+/// use acl::math;
 ///
 /// assert_eq!(math::pow_mod(2, 10000, 7), 2);
 /// ```
@@ -63,7 +63,7 @@ pub fn pow_mod(x: i64, mut n: i64, m: u32) -> u32 {
 /// # Example
 ///
 /// ```
-/// use ac_library_rs::math;
+/// use acl::math;
 ///
 /// assert_eq!(math::inv_mod(3, 7), 5);
 /// ```
@@ -106,7 +106,7 @@ pub fn inv_mod(x: i64, m: i64) -> i64 {
 /// # Example
 ///
 /// ```
-/// use ac_library_rs::math;
+/// use acl::math;
 ///
 /// let r = [2, 3, 2];
 /// let m = [3, 5, 7];
@@ -181,7 +181,7 @@ pub fn crt(r: &[i64], m: &[i64]) -> (i64, i64) {
 /// # Example
 ///
 /// ```
-/// use ac_library_rs::math;
+/// use acl::math;
 ///
 /// assert_eq!(math::floor_sum(6, 5, 4, 3), 13);
 /// ```

--- a/src/modint.rs
+++ b/src/modint.rs
@@ -3,7 +3,7 @@
 //! For most of the problems, It is sufficient to use [`ModInt1000000007`] or [`ModInt998244353`], which can be used as follows.
 //!
 //! ```
-//! use ac_library_rs::ModInt1000000007 as Mint; // rename to whatever you want
+//! use acl::ModInt1000000007 as Mint; // rename to whatever you want
 //! use proconio::{input, source::once::OnceSource};
 //!
 //! input! {
@@ -18,7 +18,7 @@
 //! If the modulus is not fixed, you can use [`ModInt`] as follows.
 //!
 //! ```
-//! use ac_library_rs::ModInt as Mint; // rename to whatever you want
+//! use acl::ModInt as Mint; // rename to whatever you want
 //! use proconio::{input, source::once::OnceSource};
 //!
 //! input! {
@@ -73,7 +73,7 @@ pub type ModInt = DynamicModInt<DefaultId>;
 /// # Example
 ///
 /// ```
-/// use ac_library_rs::ModInt1000000007 as Mint;
+/// use acl::ModInt1000000007 as Mint;
 /// use proconio::{input, source::once::OnceSource};
 ///
 /// input! {
@@ -99,7 +99,7 @@ impl<M: Modulus> StaticModInt<M> {
     /// # Example
     ///
     /// ```
-    /// use ac_library_rs::ModInt1000000007 as Mint;
+    /// use acl::ModInt1000000007 as Mint;
     ///
     /// assert_eq!(1_000_000_007, Mint::modulus());
     /// ```
@@ -217,13 +217,13 @@ impl<M: Modulus> ModIntBase for StaticModInt<M> {
 ///             #[derive(Copy, Clone, Eq, PartialEq)]
 ///             enum $name {}
 ///
-///             impl ac_library_rs::modint::Modulus for $name {
+///             impl acl::modint::Modulus for $name {
 ///                 const VALUE: u32 = $value;
 ///                 const HINT_VALUE_IS_PRIME: bool = $is_prime;
 ///
-///                 fn butterfly_cache() -> &'static ::std::thread::LocalKey<::std::cell::RefCell<::std::option::Option<ac_library_rs::modint::ButterflyCache<Self>>>> {
+///                 fn butterfly_cache() -> &'static ::std::thread::LocalKey<::std::cell::RefCell<::std::option::Option<acl::modint::ButterflyCache<Self>>>> {
 ///                     thread_local! {
-///                         static BUTTERFLY_CACHE: ::std::cell::RefCell<::std::option::Option<ac_library_rs::modint::ButterflyCache<$name>>> = ::std::default::Default::default();
+///                         static BUTTERFLY_CACHE: ::std::cell::RefCell<::std::option::Option<acl::modint::ButterflyCache<$name>>> = ::std::default::Default::default();
 ///                     }
 ///                     &BUTTERFLY_CACHE
 ///                 }
@@ -232,7 +232,7 @@ impl<M: Modulus> ModIntBase for StaticModInt<M> {
 ///     };
 /// }
 ///
-/// use ac_library_rs::StaticModInt;
+/// use acl::StaticModInt;
 ///
 /// modulus!(Mod101(101, true), Mod103(103, true));
 ///
@@ -294,7 +294,7 @@ pub struct ButterflyCache<M> {
 /// # Example
 ///
 /// ```
-/// use ac_library_rs::ModInt as Mint;
+/// use acl::ModInt as Mint;
 /// use proconio::{input, source::once::OnceSource};
 ///
 /// input! {
@@ -325,7 +325,7 @@ impl<I: Id> DynamicModInt<I> {
     /// # Example
     ///
     /// ```
-    /// use ac_library_rs::ModInt as Mint;
+    /// use acl::ModInt as Mint;
     ///
     /// assert_eq!(998_244_353, Mint::modulus()); // default modulus
     /// ```
@@ -345,7 +345,7 @@ impl<I: Id> DynamicModInt<I> {
     /// # Example
     ///
     /// ```
-    /// use ac_library_rs::ModInt as Mint;
+    /// use acl::ModInt as Mint;
     ///
     /// Mint::set_modulus(7);
     /// assert_eq!(7, Mint::modulus());
@@ -547,7 +547,7 @@ pub trait ModIntBase:
     /// # Example
     ///
     /// ```
-    /// use ac_library_rs::modint::ModIntBase;
+    /// use acl::modint::ModIntBase;
     ///
     /// fn f<Z: ModIntBase>() {
     ///     let _: u32 = Z::modulus();
@@ -567,7 +567,7 @@ pub trait ModIntBase:
     /// If `val` is greater than or equal to `Self::modulus()`, the behaviors are not defined.
     ///
     /// ```should_panic
-    /// use ac_library_rs::ModInt1000000007 as Mint;
+    /// use acl::ModInt1000000007 as Mint;
     ///
     /// let x = Mint::raw(1_000_000_007);
     /// let y = x + x;
@@ -584,7 +584,7 @@ pub trait ModIntBase:
     /// # Example
     ///
     /// ```
-    /// use ac_library_rs::modint::ModIntBase;
+    /// use acl::modint::ModIntBase;
     ///
     /// fn f<Z: ModIntBase>() -> Z {
     ///     debug_assert!(Z::modulus() >= 100);
@@ -608,7 +608,7 @@ pub trait ModIntBase:
     /// # Example
     ///
     /// ```
-    /// use ac_library_rs::modint::ModIntBase;
+    /// use acl::modint::ModIntBase;
     ///
     /// fn f<Z: ModIntBase>(x: Z) {
     ///     let _: u32 = x.val();
@@ -627,7 +627,7 @@ pub trait ModIntBase:
     /// # Example
     ///
     /// ```
-    /// use ac_library_rs::modint::ModIntBase;
+    /// use acl::modint::ModIntBase;
     ///
     /// fn f<Z: ModIntBase>(x: Z) {
     ///     let _: Z = x.inv();
@@ -642,7 +642,7 @@ pub trait ModIntBase:
     /// # Example
     ///
     /// ```
-    /// use ac_library_rs::modint::ModIntBase;
+    /// use acl::modint::ModIntBase;
     ///
     /// fn f<Z: ModIntBase>() {
     ///     let _ = Z::new(1u32);
@@ -664,7 +664,7 @@ pub trait ModIntBase:
     /// # Example
     ///
     /// ```
-    /// use ac_library_rs::modint::ModIntBase;
+    /// use acl::modint::ModIntBase;
     ///
     /// fn f<Z: ModIntBase>() {
     ///     let _: Z = Z::new(2).pow(3);

--- a/src/scc.rs
+++ b/src/scc.rs
@@ -7,7 +7,7 @@ use crate::internal_scc;
 /// # Example
 ///
 /// ```
-/// use ac_library_rs::SccGraph;
+/// use acl::SccGraph;
 /// use proconio::{input, source::once::OnceSource};
 ///
 /// input! {

--- a/src/twosat.rs
+++ b/src/twosat.rs
@@ -16,7 +16,7 @@ use crate::internal_scc;
 /// ```
 /// #![allow(clippy::many_single_char_names)]
 ///
-/// use ac_library_rs::TwoSat;
+/// use acl::TwoSat;
 /// use proconio::{input, marker::Bytes, source::once::OnceSource};
 ///
 /// input! {


### PR DESCRIPTION
Resolves #47.

package name: `ac-library-rs` (as is)
crate name: `ac_library_rs` → **`acl`**
