### PR TITLE
Remove `package.authors`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ac-library-rs"
 version = "0.1.0"
-authors = ["rust-lang-ja Developers"]
 edition = "2018"
 description = "A Rust port of AtCoder Library (ACL)."
 license = "CC0-1.0"


### PR DESCRIPTION
Removes `package.authors`.

This field is not deprecated yet, but is no longer used unless explicitly used for functions such as `clap`.

<https://github.com/rust-lang/rust/issues/83227>
