### PR TITLE
Correct `n` to refer to vertices, not edges in `SccGraph::new`

### DIFF
--- a/src/scc.rs
+++ b/src/scc.rs
@@ -36,7 +36,7 @@ pub struct SccGraph {
 }
 
 impl SccGraph {
-    /// Creates a new `SccGraph` with `n` edges.
+    /// Creates a new `SccGraph` with `n` vertices and `0` edges.
     ///
     /// # Constraints
     ///


### PR DESCRIPTION
Resolve: #155 

This PR updates the doc comment for `SccGraph::new(n)`, correcting the description of `n` to refer to **vertices** instead of edges.  

[Original documentation](https://atcoder.github.io/ac-library/production/document_en/scc.html)