### PR TITLE
Implement `Clone` and `Debug` for `internal_scc::SccGraph` and `Debug` for `_Edge`

### DIFF
--- a/src/internal_scc.rs
+++ b/src/internal_scc.rs
@@ -27,7 +27,7 @@ where
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 struct _Edge {
     to: usize,
 }
@@ -35,6 +35,7 @@ struct _Edge {
 /// Reference:
 /// R. Tarjan,
 /// Depth-First Search and Linear Graph Algorithms
+#[derive(Clone, Debug)]
 pub struct SccGraph {
     n: usize,
     edges: Vec<(usize, _Edge)>,


### PR DESCRIPTION
Resolves #147

This PR implements the `Clone` and `Debug` traits for `internal_scc::SccGraph` and the `Debug` trait for `_Edge`.
As proposed in the issue, both traits are implemented using `derive`.