### PR TITLE
Implement `Clone` and `Debug` for `TwoSat`

### DIFF
--- a/src/twosat.rs
+++ b/src/twosat.rs
@@ -48,6 +48,7 @@ use crate::internal_scc;
 /// assert!(twosat.satisfiable());
 /// assert_eq!(twosat.answer(), [false, true, true]);
 /// ```
+#[derive(Clone, Debug)]
 pub struct TwoSat {
     n: usize,
     scc: internal_scc::SccGraph,


### PR DESCRIPTION
Resolves #149

This PR implements the `Clone` and `Debug` traits for `TwoSat`.
As proposed in the issue, both traits are implemented using `derive`.