### PR TITLE
Implement `Clone` and `Debug` for `MfGraph` and `_Edge`

### DIFF
--- a/src/maxflow.rs
+++ b/src/maxflow.rs
@@ -207,13 +207,14 @@ where
     }
 }
 
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct MfGraph<Cap> {
     _n: usize,
     pos: Vec<(usize, usize)>,
     g: Vec<Vec<_Edge<Cap>>>,
 }
 
+#[derive(Clone, Debug)]
 struct _Edge<Cap> {
     to: usize,
     rev: usize,


### PR DESCRIPTION
Resolves #150

This PR implements the `Clone` and `Debug` traits for `MfGraph` and `_Edge`.
As proposed in the issue, both traits are implemented using `derive`.