### PR TITLE
Implement `Clone` for `Edge`

### DIFF
--- a/src/maxflow.rs
+++ b/src/maxflow.rs
@@ -34,7 +34,7 @@ where
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Edge<Cap: Integral> {
     pub from: usize,
     pub to: usize,


### PR DESCRIPTION
Resolves #151

This PR implements the `Clone` trait for `Edge`.
As proposed in the issue, the trait is implemented using `derive`.