### PR TITLE
Implement `Clone` and `Debug` for `SccGraph`

### DIFF
--- a/src/scc.rs
+++ b/src/scc.rs
@@ -31,6 +31,7 @@ use crate::internal_scc;
 ///
 /// assert_eq!(graph.scc(), [&[0, 1, 2][..], &[3], &[4]]);
 /// ```
+#[derive(Clone, Debug)]
 pub struct SccGraph {
     internal: internal_scc::SccGraph,
 }


### PR DESCRIPTION
Resolves #148

This PR implements the `Clone` and `Debug` traits for `SccGraph`.
As proposed in the issue, both traits are implemented using `derive`.