### PR TITLE
Implement `Clone` and `Debug` for `MinCostFlowGraph` and `_Edge`

### DIFF
--- a/src/mincostflow.rs
+++ b/src/mincostflow.rs
@@ -8,6 +8,7 @@ pub struct MinCostFlowEdge<T> {
     pub cost: T,
 }
 
+#[derive(Clone, Debug)]
 pub struct MinCostFlowGraph<T> {
     pos: Vec<(usize, usize)>,
     g: Vec<Vec<_Edge<T>>>,
@@ -172,6 +173,7 @@ where
     }
 }
 
+#[derive(Clone, Debug)]
 struct _Edge<T> {
     to: usize,
     rev: usize,


### PR DESCRIPTION
Resolves #152

This PR implements the `Clone` and `Debug` traits for `MinCostFlowGraph` and `_Edge`.
As proposed in the issue, both traits are implemented using `derive`.