### PR TITLE
Implement `Clone` and `Debug` for `MinCostFlowEdge`

### DIFF
--- a/src/mincostflow.rs
+++ b/src/mincostflow.rs
@@ -1,5 +1,6 @@
 use crate::internal_type_traits::Integral;
 
+#[derive(Clone, Debug)]
 pub struct MinCostFlowEdge<T> {
     pub from: usize,
     pub to: usize,


### PR DESCRIPTION
Resolves #153

This PR implements the `Clone` and `Debug` traits for `MinCostFlowEdge`.
As proposed in the issue, both traits are implemented using `derive`.