### PR TITLE
Implement `Clone` and `Debug` for `FenwickTree`

### DIFF
--- a/src/fenwicktree.rs
+++ b/src/fenwicktree.rs
@@ -63,9 +63,7 @@ impl<T: Clone + Debug + std::ops::AddAssign<T>> Debug for FenwickTree<T> {
             .field("n", &self.n)
             .field(
                 "accum",
-                &(1..=self.n)
-                    .map(|i| self.accum(i))
-                    .collect::<Vec<_>>(),
+                &(1..=self.n).map(|i| self.accum(i)).collect::<Vec<_>>(),
             )
             .field("e", &self.e)
             .finish()?;

--- a/src/fenwicktree.rs
+++ b/src/fenwicktree.rs
@@ -1,6 +1,8 @@
+use std::fmt::{Debug, Error, Formatter};
 use std::ops::{Bound, RangeBounds};
 
 // Reference: https://en.wikipedia.org/wiki/Fenwick_tree
+#[derive(Clone)]
 pub struct FenwickTree<T> {
     n: usize,
     ary: Vec<T>,
@@ -52,6 +54,22 @@ impl<T: Clone + std::ops::AddAssign<T>> FenwickTree<T> {
             Bound::Unbounded => return self.accum(r),
         };
         self.accum(r) - self.accum(l)
+    }
+}
+
+impl<T: Clone + Debug + std::ops::AddAssign<T>> Debug for FenwickTree<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+        f.debug_struct("FenwickTree")
+            .field("n", &self.n)
+            .field(
+                "accum",
+                &(1..=self.n)
+                    .map(|i| self.accum(i))
+                    .collect::<Vec<_>>(),
+            )
+            .field("e", &self.e)
+            .finish()?;
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Resolves #145

This draft PR implements the `Clone` and `Debug` traits for `FenwickTree`.
The `Clone` trait is implemented using `derive`.

As mentioned in the issue, the `Debug` implementation uses the `debug_struct` function to display the fields `n`, `accum`, and `e`.
I would mainly like to confirm the following points:
- Whether the proposed output format is acceptable,
- Whether generating a `Vec` to display `accum` as a list is reasonable,
- And whether using a method chain for this implementation is appropriate.