### PR TITLE
Implement `Clone` for `FenwickTree`

### DIFF
--- a/src/fenwicktree.rs
+++ b/src/fenwicktree.rs
@@ -1,6 +1,7 @@
 use std::ops::{Bound, RangeBounds};
 
 // Reference: https://en.wikipedia.org/wiki/Fenwick_tree
+#[derive(Clone)]
 pub struct FenwickTree<T> {
     n: usize,
     ary: Vec<T>,


### PR DESCRIPTION
Related to #145

This PR implements the `Clone` trait for `FenwickTree`. 
The trait is implemented using `derive`.