### PR TITLE
Implement `Clone` for `LazySegtree`

### DIFF
--- a/src/lazysegtree.rs
+++ b/src/lazysegtree.rs
@@ -291,6 +291,7 @@ impl<F: MapMonoid> LazySegtree<F> {
     }
 }
 
+#[derive(Clone)]
 pub struct LazySegtree<F>
 where
     F: MapMonoid,


### PR DESCRIPTION
Related to #143

This PR implements the `Clone` trait for `LazySegtree`.  
The trait is implemented using `derive`.

`LazySegtree` already has a `Debug` implementation, but since it is still open to discussion, this PR avoids closing the issue automatically.