### PR TITLE
Implement `Clone` for `Segtree`

### DIFF
--- a/src/segtree.rs
+++ b/src/segtree.rs
@@ -298,6 +298,7 @@ impl<M: Monoid> Segtree<M> {
 // }
 // ```
 
+#[derive(Clone)]
 pub struct Segtree<M>
 where
     M: Monoid,


### PR DESCRIPTION
Related to #144

This PR implements the `Clone` trait for `Segtree`. 
The trait is implemented using `derive`.