### PR TITLE
Implement `Debug` for `FenwickTree`

### DIFF
--- a/src/fenwicktree.rs
+++ b/src/fenwicktree.rs
@@ -1,3 +1,4 @@
+use std::fmt::{Debug, Error, Formatter};
 use std::ops::{Bound, RangeBounds};
 
 // Reference: https://en.wikipedia.org/wiki/Fenwick_tree
@@ -53,6 +54,20 @@ impl<T: Clone + std::ops::AddAssign<T>> FenwickTree<T> {
             Bound::Unbounded => return self.accum(r),
         };
         self.accum(r) - self.accum(l)
+    }
+}
+
+impl<T: Clone + Debug + std::ops::AddAssign<T>> Debug for FenwickTree<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+        f.debug_struct("FenwickTree")
+            .field("n", &self.n)
+            .field(
+                "accum",
+                &(1..=self.n).map(|i| self.accum(i)).collect::<Vec<_>>(),
+            )
+            .field("e", &self.e)
+            .finish()?;
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Resolves #145

This draft PR implements the `Debug` trait for `FenwickTree`.
The previous draft PR with the same content was unintentionally closed, so I’ve created a new branch to both reopen it and clean up the commit history.
Below is the same explanation as before, for reference.

As mentioned in the issue, the `Debug` implementation uses the `debug_struct` function to display the fields `n`, `accum`, and `e`.
I would mainly like to confirm the following points:
- Whether the proposed output format is acceptable,
- Whether generating a `Vec` to display `accum` as a list is reasonable,
- And whether using a method chain for this implementation is appropriate.