### PR TITLE
Fix typo in src/twosat.rs

### DIFF
--- a/src/twosat.rs
+++ b/src/twosat.rs
@@ -3,7 +3,7 @@ use crate::internal_scc;
 
 /// A 2-SAT Solver.
 ///
-/// For variables $x_0, x_1, \ldots, x_{N - 1}$ and clauses with from
+/// For variables $x_0, x_1, \ldots, x_{N - 1}$ and clauses with form
 ///
 /// \\[
 ///   (x_i = f) \lor (x_j = g)


### PR DESCRIPTION
from -> form

NOTE: This is a comment-only change, no logic changes.

[Original Documentation](https://atcoder.github.io/ac-library/master/document_en/twosat.html)