### PR TITLE
Fix small documentation issues in `src/convolution.rs`

### DIFF
--- a/src/convolution.rs
+++ b/src/convolution.rs
@@ -46,7 +46,7 @@ use std::{
 ///
 /// See the [module-level documentation] for more details.
 ///
-/// Returns a empty `Vec` if `a` or `b` is empty.
+/// Returns an empty `Vec` if `a` or `b` is empty.
 ///
 /// # Constraints
 ///
@@ -133,7 +133,7 @@ where
 ///
 /// See the [module-level documentation] for more details.
 ///
-/// Returns a empty `Vec` if `a` or `b` is empty.
+/// Returns an empty `Vec` if `a` or `b` is empty.
 ///
 /// # Constraints
 ///
@@ -206,7 +206,7 @@ where
 ///
 /// See the [module-level documentation] for more details.
 ///
-/// Returns a empty `Vec` if `a` or `b` is empty.
+/// Returns an empty `Vec` if `a` or `b` is empty.
 ///
 /// # Constraints
 ///

--- a/src/convolution.rs
+++ b/src/convolution.rs
@@ -140,7 +140,7 @@ where
 /// - $2 \leq m \leq 2 \times 10^9$
 /// - $m$ is a prime number.
 /// - $\exists c \text{ s.t. } 2^c \mid (m - 1), |a| + |b| - 1 \leq 2^c$
-/// - $(0, m] \subseteq$ `T`
+/// - $[0, m) \subseteq$ `T`
 ///
 /// where $m$ is `M::VALUE`.
 ///


### PR DESCRIPTION
NOTE: This is a comment-only change, no logic changes.

## Changes

- Fix the documented range constraint for `convolution_raw` from `(0, m] \subseteq T` to `[0, m) \subseteq T`.
- Fix "Returns a empty `Vec`" to "Returns an empty `Vec`".

## Details

`convolution_raw` converts each result back to `T` using:

```rust
z.val().try_into()
```

Since `StaticModInt::val()` returns a representative in `[0, M::VALUE)`, `T` needs to be able to represent `[0, m)`, not `(0, m]`.